### PR TITLE
Advance basicdoc pin; construct doctrine, conformance clause, ISO 24229, spec drift fixes

### DIFF
--- a/sources/cc-36010.adoc
+++ b/sources/cc-36010.adoc
@@ -36,6 +36,8 @@ include::sections/01-scope.adoc[]
 
 include::sections/02-norm-refs.adoc[]
 
+include::sections/01a-conformance.adoc[]
+
 include::sections/03-terms.adoc[]
 
 include::sections/04-modelling.adoc[]

--- a/sources/iso-36010.adoc
+++ b/sources/iso-36010.adoc
@@ -37,6 +37,8 @@ include::sections/01-scope.adoc[]
 
 include::sections/02-norm-refs.adoc[]
 
+include::sections/01a-conformance.adoc[]
+
 include::sections/03-terms.adoc[]
 
 include::sections/04-modelling.adoc[]

--- a/sources/sections/00-intro.adoc
+++ b/sources/sections/00-intro.adoc
@@ -23,8 +23,8 @@ the lowest common denominator in parsing support, which is
 plain text, with no defined human- or machine-understandable
 structure.
 
-The _BasicDocument_ model is created to express the structure of
-generic documents in a lightweight form.
+The _BasicDocument_ model (also known as _BasicDoc_ or _SecureDoc_) is
+created to express the structure of generic documents in a lightweight form.
 
 _BasicDocument_ achieves a number of goals:
 

--- a/sources/sections/01a-conformance.adoc
+++ b/sources/sections/01a-conformance.adoc
@@ -1,0 +1,22 @@
+[[conformance]]
+== Conformance
+
+The LutaML definition modules (`models/**/*.lml` in the model repository)
+are the definitive expression of this document model. The RelaxNG Compact
+grammars accompanying them are implementation grammars for validation;
+the diagrams reproduced in this document are informative.
+
+A serialization or implementation conforms to this model if it can
+represent every construct of the model without loss. This model is
+intended as a complete superset of lightweight markup languages
+(AsciiDoc, Markdown and its flavours, reStructuredText) and richer
+document formats: a construct of such a format is covered if it maps to:
+
+. an existing construct of this model;
+. a type-specialization of such a construct; or
+. entries in the attribute register, together with relaxed or opaque
+  (raw) content.
+
+The following are preprocessing or rendering concerns, and are out of
+scope: attribute conditionals, content inclusion, table-of-content
+generation, smart punctuation, and citation rendering modes.

--- a/sources/sections/02-norm-refs.adoc
+++ b/sources/sections/02-norm-refs.adoc
@@ -5,8 +5,9 @@
 * [[[relaton,ISO 6900:--]]] footnote:[In draft], _Information and documentation -- Bibliographic reference model and serialization_
 * [[[rfc3986,IETF RFC 3986]]], _Uniform Resource Identifier (URI): Generic Syntax_
 * [[[iso639,ISO 639 (all parts)]]], _Codes for the representation of names of languages_
-* [[[iso8601-1,ISO 8601-1]]], _AUTOFILL_
-* [[[iso8601-2,ISO 8601-2]]], _AUTOFILL_
+* [[[iso8601-1,ISO 8601-1:2019]]], _Date and time — Representations for information interchange — Part 1: Basic rules_
+* [[[iso8601-2,ISO 8601-2:2019]]], _Date and time — Representations for information interchange — Part 2: Extensions_
 * [[[iso10118,ISO/IEC 10118 (all parts)]]], _Information technology -- Security techniques -- Hash-functions_
 * [[[iso14888,ISO/IEC 14888 (all parts)]]], _Information technology -- Security techniques -- Digital signatures with appendix_
 * [[[iso15924,ISO 15924]]], _Information and documentation -- Codes for the representation of names of scripts_
+* [[[iso3166,ISO 3166 (all parts)]]], _Codes for the representation of names of countries and their subdivisions_

--- a/sources/sections/02-norm-refs.adoc
+++ b/sources/sections/02-norm-refs.adoc
@@ -11,3 +11,4 @@
 * [[[iso14888,ISO/IEC 14888 (all parts)]]], _Information technology -- Security techniques -- Digital signatures with appendix_
 * [[[iso15924,ISO 15924]]], _Information and documentation -- Codes for the representation of names of scripts_
 * [[[iso3166,ISO 3166 (all parts)]]], _Codes for the representation of names of countries and their subdivisions_
+* [[[iso24229,ISO 24229]]], _Information and documentation — Written-language conversion systems_

--- a/sources/sections/02-norm-refs.adoc
+++ b/sources/sections/02-norm-refs.adoc
@@ -2,7 +2,7 @@
 [bibliography]
 == Normative references
 
-* [[[relaton,ISO 6900:--]]] footnote:[In draft], _Information and documentation -- Bibliographic reference model and serialization_
+* [[[relaton,CC/ISO 6900:--]]] footnote:[In draft], _Information and documentation -- Bibliographic reference model and serialization_
 * [[[rfc3986,IETF RFC 3986]]], _Uniform Resource Identifier (URI): Generic Syntax_
 * [[[iso639,ISO 639 (all parts)]]], _Codes for the representation of names of languages_
 * [[[iso8601-1,ISO 8601-1:2019]]], _Date and time — Representations for information interchange — Part 1: Basic rules_

--- a/sources/sections/04-modelling.adoc
+++ b/sources/sections/04-modelling.adoc
@@ -17,6 +17,45 @@ Specialization of a model consists of:
 * Changing attributes of a base model class. This is not restricted to adding attributes, as is the case in typical entity subclassing; it can also include removing attributes from a class, changing their obligation and cardinality, and changing their type, including changing enumerations. Attributes can be overruled at any level; for example, standards-specific models routinely enhance the bibliographic model at the base of the hierarchy.
 * For reasons of clarity, renaming classes and attributes is avoided in specialisation.
 
+=== Constructs, types, and specialization
+
+The _BasicDocument_ model provides generic _constructs_; markup languages and
+document models _specialize them as types_. The model does not enumerate a
+class per format feature: admonition kinds such as Note, Warning, Caution are
+values of the _AdmonitionType_ of a single _Admonition_ construct, and
+markup-specific kinds arrive through type values or subclassing. A foreign
+construct is covered by this model if it maps to an existing construct, a
+type-specialization of one, or register entries with relaxed or opaque
+content (see <<conformance>>).
+
+=== Attribute register
+
+Attributes form an open _register_: any construct (document, section, block,
+inline element) carries a set of key-value _Attribute_ entries, optionally
+qualified by a scheme. Markup languages bind their own attribute types as
+register entries; this model deliberately does not enumerate them. Keys with
+established cross-format meaning include `id`, `class`, `lang`, `script`,
+`unnumbered`, `subsequence`, and `format`.
+
+=== Composition
+
+A document is itself a block: entire documents may be attached as child
+content of any container whose content model accepts blocks. Content models
+of containers (list items, multi-paragraph blocks, definition-list
+definitions, table cells, examples) are accordingly _relaxed_: they contain
+zero or more blocks, not only paragraphs.
+
+=== Variables and raw content
+
+References to variables (attribute references in AsciiDoc, substitutions in
+RST, template variables) are modelled as a _ReferenceToVariable_ inline
+element resolving, at processing time, against the attribute register.
+Raw or passthrough content is non-markup content the model does not
+interpret: inline raw content is a _FormattedString_ (whose `format`
+attribute exists precisely to admit markup into strings), and block-level
+raw content is a string-carrying construct qualified by a `format` register
+entry.
+
 === Structure
 
 The classes involved in the document model are of three classes:

--- a/sources/sections/05-basicdoc.adoc
+++ b/sources/sections/05-basicdoc.adoc
@@ -4,10 +4,7 @@
 
 The _BasicDocument_ model treats all documents as collections of _sections_ (<<basicsection>>). It also adds the following metadata as part of the document model:
 
-// Please confirm what I've assumed here for identifier
-// TODO: I'm surprised it's mandatory: that certainly is not the case for Metanorma!
-
-`identifier`:: a globally unique identifier for the document in an agreed identifier schema. The identifier is to be used for tracking interactions with the document without depending on formal document registries; it would be exemplified by a GUID, rather than a document registry identifier such as "`ISO 639`", which belongs to `bibdata`.
+`identifier`:: an optional globally unique identifier for the document in an agreed identifier schema. The identifier is to be used for tracking interactions with the document without depending on formal document registries; it would be exemplified by a GUID, rather than a document registry identifier such as "`ISO 639`", which belongs to `bibdata`.
 
 `bibdata`:: a bibliographic description, capturing bibliographic metadata about the document itself, including authors, title, and date of production.
 

--- a/sources/sections/07-sections.adoc
+++ b/sources/sections/07-sections.adoc
@@ -17,6 +17,7 @@ All sections are modelled as having the following attributes:
 `id`:: an optional identifier for the section, to be used for cross-references within the document. (Citations of references are modelled as cross-references to the corresponding bibliographical item in the References section.)
 `language`:: zero or more language tags for the section, coded as <<iso639>> codes.
 `script`:: zero or more script tags for the section, coded as <<iso15924>> codes.
+The combination of language and script identifies a spelling system as registered under <<iso24229>>.
 `blocks`:: zero or more text blocks, containing the textual content of the section (but excluding subsections, which are only present in Hierarchical Sections). Notes are not given a separate attribute: a note is itself a block, modelled as an admonition of type _note_.
 
 

--- a/sources/sections/07-sections.adoc
+++ b/sources/sections/07-sections.adoc
@@ -17,8 +17,7 @@ All sections are modelled as having the following attributes:
 `id`:: an optional identifier for the section, to be used for cross-references within the document. (Citations of references are modelled as cross-references to the corresponding bibliographical item in the References section.)
 `language`:: zero or more language tags for the section, coded as <<iso639>> codes.
 `script`:: zero or more script tags for the section, coded as <<iso15924>> codes.
-`blocks`:: zero or more text blocks, containing the textual content of the section (but excluding subsections, which are only present in Hierarchical Sections).
-`notes`:: any notes whose scope is the entire section, rather than a specific block. Notes are modelled as a sequence of zero or more paragraphs.
+`blocks`:: zero or more text blocks, containing the textual content of the section (but excluding subsections, which are only present in Hierarchical Sections). Notes are not given a separate attribute: a note is itself a block, modelled as an admonition of type _note_.
 
 
 //(notably for Metanorma the ISO document model)

--- a/sources/sections/08-blocks.adoc
+++ b/sources/sections/08-blocks.adoc
@@ -47,7 +47,8 @@ image::basicdoc-models/images/Paragraphs.png[]
 
 ==== General
 
-The following classes of block are modelled as containing zero or more paragraphs.
+The following classes of block are modelled as containers of zero or more
+blocks; the paragraphs of their name are the typical case.
 
 .Basic Document model: Multi-paragraph Block
 image::basicdoc-models/images/MultiParagraphs.png[]
@@ -64,7 +65,7 @@ _Blockquote_, which also contains an optional bibliographic citation for the quo
 
 _Admonition_, which captures sidebars to the main text conveying particular warnings or supplementary text to the reader. The Admonition block includes a `name` (title), a `class` (subcategory), a `uri` (in case the admonition is available as a separate external document), and a `type` of admonition. 
 
-The `type` of admonition determines the rendering of the admonition; the `class` allows different runs of admonitions to be labelled and auto-numbered differently, even if they are of the same type. The defined types for the _BasicDocument_ model are _Warning, Note, Tip, Important, Caution, and Statement_. (In rendering, distinct admonition types are often associated with distinct icons or rendering.)
+The `type` of admonition determines the rendering of the admonition; the `class` allows different runs of admonitions to be labelled and auto-numbered differently, even if they are of the same type. The types defined for the _BasicDocument_ model are _warning, note, tip, important,_ and _caution_ (in rendering, distinct admonition types are often associated with distinct icons or rendering). Further kinds, such as _statement_, _danger_, _error,_ or _hint,_ are provided by specializations of this model, not by this model itself.
 
 NOTE: Statement is intended for typographically separate statements in mathematics, such as propositions, proofs, or theorems. Statement conflates all of these for rendering, while Proposition, Proof, Theorem etc. can be treated as distinct classes.
 
@@ -74,7 +75,7 @@ NOTE: Admonition notes are modelled to be distinct from notes under sections or 
 [[review]]
 ==== Review
 
-_Review_, which is intended to capture reviewer comments about some text in the document. The Review block includes the following attributes: an optional string identifying the `reviewer` who offered the comment; an optional `date` when the comment was made; a mandatory identifier for the start of the text to which the comment applies (`appliesFrom`), and an optional identifier for the end of the text to which the comment applies (`appliesTo`).
+_Review_, which is intended to capture reviewer comments about some text in the document. The Review block includes the following attributes: an optional string identifying the `reviewer` who offered the comment; an optional `date` when the comment was made; an optional `type` of reviewer comment; an optional identifier for the start of the text to which the comment applies (`appliesFrom`), and an optional identifier for the end of the text to which the comment applies (`appliesTo`). If `appliesFrom` is absent, the comment applies in the vicinity of the place it has been inserted into the text.
 
 NOTE: If the `appliesTo` identifier of a Review block is absent, the comment applies only to the span of text identified by the `appliesFrom` identifier; if it is present, the comments applies to the span of text between the start of the span of text identified by `appliesFrom`, and the end of the span of text identified by `appliesTo`.
 
@@ -118,7 +119,7 @@ _Table rows_ are defined as a sequence of zero or more header cells and data cel
 
 ==== Table cells
 
-_Table cells_ contain either zero or more paragraphs with footnotes (<<basicpara>>), or zero or more text elements (<<textelements>>). In addition, they have the following optional rendering attributes, which are aligned with HTML:
+_Table cells_ contain either zero or more text elements (<<textelements>>), footnotes included, or zero or more blocks (<<basicblock>>) — the cell content model is relaxed, matching the container rule of <<conformance>>; markup that admits block content in cells (e.g. AsciiDoc `a|` cells) maps directly. In addition, they have the following optional rendering attributes, which are aligned with HTML:
 
 `colspan`:: Number of columns in the underlying table grid which the cell spans.
 
@@ -132,13 +133,13 @@ _Table cells_ contain either zero or more paragraphs with footnotes (<<basicpara
 [[basiclist]]
 === List
 
-Lists are modelled following the same principles as HTML lists. All lists contain zero or more _list items_, which by default consist of an identifier (`id`), and one or more paragraphs with footnotes (<<basicpara>>). This allows individual list items in a list to be cross-referenced within the document.
+Lists are modelled following the same principles as HTML lists. All lists contain zero or more _list items_, which consist of an optional identifier (`id`), and zero or more blocks (<<basicblock>>) — list item content is relaxed, so markup whose items contain arbitrary blocks (loose Markdown lists, AsciiDoc continuations, RST items) maps directly. The identifier allows individual list items to be cross-referenced within the document.
 
 Three subclasses of List are modelled.
 
 * _Unordered lists_ are equivalent to the List base class.
 
-* _Ordered lists_ are Lists with a `type` attribute, describing the kind of numeration applied to the List; the values allowed under the _BasicDocument_ model are _roman, alphabet, arabic, roman_upper, alphabet_upper_, corresponding to lowercase Roman numerals, lowercase alphabetic letters, Arabic numerals, uppercase Roman numerals, and uppercase alphabetic letters.
+* _Ordered lists_ are Lists with a `type` attribute, describing the kind of numeration applied to the List; the values allowed under the _BasicDocument_ model are _roman, alphabet, arabic, romanUpper, alphabetUpper_, corresponding to lowercase Roman numerals, lowercase alphabetic letters, Arabic numerals, uppercase Roman numerals, and uppercase alphabetic letters.
 
 * _Definition lists_ override the definition of the List Item to be a pair of `item` (zero or more text elements: <<textelements>>) and `definition` (zero or more paragraphs with footnotes: <<basicpara>>).
 
@@ -240,15 +241,7 @@ It contains the following elements (which are a subset of the elements of Source
 [[basicexample]]
 ==== Example
 
-Example blocks are wrappers for open-ended example text. They consist of a combination of any of the following blocks:
-
-* Formula
-* List
-* Blockquote (which is how generic text is included in an example)
-* Sourcecode
-* Paragraph
-
-It also contains the following elements:
+Example blocks are wrappers for open-ended example content: they contain zero or more blocks (<<basicblock>>), an extension point that higher layers may extend additively. They also contain:
 
 `unnumbered`:: An optional boolean attribute indicating that the example should be excluded from any automatic numbering of examples in the document.
 
@@ -256,3 +249,30 @@ It also contains the following elements:
 
 `name`:: A label for the example.
 
+
+
+[[amend]]
+=== Amend
+
+The _AmendBlock_ describes a change in a document for human readers, as
+opposed to the machine-readable _Change_ models (<<change-models>>).
+
+`change`:: the type of change described: one of _add, modify, delete, replace_ (_ChangeType_).
+`bibLocality`, `localityStack`:: the location in the original document which has undergone the change, as bibliographic localities (<<relaton>>).
+`path`, `pathEnd`:: the span within the location where the change applies, if the location defines a container larger than the scope of the change.
+`title`:: an optional caption of this block.
+`description`:: zero or more blocks describing the change.
+`newContent`:: a _NewContentBlock_ (see below).
+`classification`:: zero or more key-value classifications of the change, as attribute register entries.
+`contributor`:: zero or more contributors responsible for the change (<<relaton>>).
+`position`:: for an _add_ change, whether the change is added _before_ or _after_ the location.
+
+==== New content
+
+The _NewContentBlock_ is the composition container for amend content: it
+carries zero or more blocks (`newContentBlocks`), zero or more sections
+(`clause`), and zero or more entire documents (`document`) — a document is
+a block (see <<conformance>>), so whole documents compose as child content.
+
+.Basic Document model: Multi-paragraph and Amend Blocks
+image::basicdoc-models/images/MultiParagraphs.png[]

--- a/sources/sections/09-inline.adoc
+++ b/sources/sections/09-inline.adoc
@@ -37,13 +37,23 @@ The following elements indicate formatting, and have no further attributes:
 * Underline (corresponding to HTML 4 `u`)
 * Small Caps
 
-The following elements are used for Ruby annotations in East Asian languages, and correspond to their HTML 5 equivalents;
+The following elements are used for Ruby annotations in East Asian
+languages, and correspond to the HTML 5 `ruby`, `rt`, `rp` elements:
 
-* ruby
-* rt
-* rp
+* _RubyElement_ (the annotation base)
+* _RubyPronunciation_ (`rt`)
+* _RubyAnnotation_ (`rp`)
 
-Text Elements also include the STEM element, representing mathematical and other formulas. This consists of a `type`, indicating which language is used to express the formula, and the content of the formula itself. By default the _BasicDocument_ model allows AsciiMath and MathML in STEM elements.
+Text elements are distinguished from _Pure Text Elements_, which are
+restricted to contain only other pure text elements — no identifiers and no
+references — so that consumers that process plain runs of text can rely on
+the distinction.
+
+Text Elements also include the STEM element, representing mathematical and
+other formulas. This consists of a `stemType`, indicating which language is
+used to express the formula, and the content (`stemValue`) of the formula
+itself. The _BasicDocument_ model allows AsciiMath, MathML, and LaTeX in
+STEM elements.
 
 
 .Basic Document model: Text Elements
@@ -85,13 +95,13 @@ There are two subclasses of ID Elements in the _BasicDocument_ model:
 Media files are of three subtypes, each of which has its own element name:
 
 * _Image_ is for image files, and has the following additional attributes
-`height`:: optional attribute, which can be an integer or "auto"
-`width`:: optional attribute, which can be an integer or "auto"
+`height`:: optional attribute (<<datavalues>>): a real number with an optional percent sign, or "auto"
+`width`:: optional attribute (<<datavalues>>): a real number with an optional percent sign, or "auto"
 
 * _Audio_ is for audio files, and has the following additional attributes
 `altsource`:: zero or more specifications of alternative files to use as media. These specifications in turn consist of an optional `filename`, a `source`, and a `type`, as with the parent _Media_ class
 
-* _Video_ is for audio files, and has the following additional attributes
+* _Video_ is for video files, and has the following additional attributes
 `altsource`:: zero or more specifications of alternative files to use as media. These specifications in turn consist of an optional `filename`, a `source`, and a `type`, as with the parent _Media_ class
 `height`:: optional attribute, which can be an integer or "auto"
 `width`:: optional attribute, which can be an integer or "auto"
@@ -124,6 +134,14 @@ The Reference to ID Element class in turn has the following subclasses modelled:
 .Basic Document model: Reference Elements
 image::basicdoc-models/images/ReferenceElements.png[]
 
+
+==== Reference to Variable
+
+The _ReferenceToVariable_ element references a variable: it resolves, at
+processing time, to the value registered under its `name` in the attribute
+register (<<conformance>>). It is the model home for attribute references
+(AsciiDoc `{attr}`), substitutions (RST `|substitution|`), and template
+variables.
 
 [[footnote]]
 === Footnote

--- a/sources/sections/09-inline.adoc
+++ b/sources/sections/09-inline.adoc
@@ -121,6 +121,10 @@ The Reference to ID Element class in turn has the following subclasses modelled:
 * Callout, for which the `type` is set to _callout_, and the `text` is constrained to be a single mandatory string. The target of the callout is understood to be the location of the callout within the source code; the extent of the target is not expressed overtly.
 * Reference To ID With Paragraph Element, which associates both `text` and `content` to the cross-reference; the `content` is a sequence of one or more paragraphs (<<basicpara>>).
 
+.Basic Document model: Reference Elements
+image::basicdoc-models/images/ReferenceElements.png[]
+
+
 [[footnote]]
 === Footnote
 

--- a/sources/sections/10-data-types.adoc
+++ b/sources/sections/10-data-types.adoc
@@ -15,7 +15,13 @@ The following basic types are used in the definition of the _BasicDocument_ mode
 * Hash algorithms, as defined in <<iso10118>>.
 * Digital signature algorithms, as defined in <<iso14888>>.
 * Script names, as defined in <<iso15924>>.
-* Localized Strings, specifying a String with optional Language and Script attributes.
+* Localized Strings, specifying a String with optional language (<<iso639>>),
+  script (<<iso15924>>), and country (<<iso3166>>) attributes. A
+  language-script(-country) combination identifies a _spelling system_
+  as registered under <<iso24229>>, which also registers _system codes_
+  for written-language conversion systems (e.g. romanization and
+  transliteration schemes); a conversion system applied to content may
+  be identified through such a system code.
 * Formatted Strings, specifying a Localized String with a `format` attribute, in order to admit markup into Strings (whether XML-based or not).
 
 .Basic Document model: Data Types

--- a/sources/sections/10-data-types.adoc
+++ b/sources/sections/10-data-types.adoc
@@ -6,7 +6,10 @@
 The following basic types are used in the definition of the _BasicDocument_ model.
 
 * String
+* Attribute register entries: key-value pairs with an optional qualifying scheme (see <<conformance>>)
+* Image sizes: a real number with an optional percent sign, or "auto"
 * URI, as defined in <<rfc3986>>.
+* Country codes, as defined in <<iso3166>>.
 * Language names, as defined in <<iso639>>.
 * Dates and times, as defined in <<iso8601-1>>.
 * Hash algorithms, as defined in <<iso10118>>.
@@ -26,7 +29,12 @@ In addition to the Basic Data Values, the _BasicDocument_ model defines a contai
 
 `dateTime`:: The date and time when the contribution was made.
 `contributor`:: The party who made the contribution, as described through the `contributor` element in <<relaton>>.
-`inegrityValue`:: A digital signature of the contribution, consisting of a `hash` value and a `signature`, with an associated `publicKey`.
+`integrityValue`:: zero or more _IntegrityValue_ entries, digital signatures of the contribution.
+
+The _IntegrityValue_ class consists of a `hash` value and a `signature`,
+with an associated `publicKey`; hash algorithm identifiers follow
+<<iso10118>> and digital signature algorithm identifiers follow
+<<iso14888>>.
 
 .Basic Document model: Contribution Element Metadata
 image::basicdoc-models/images/ContribMetadata.png[]

--- a/sources/sections/11-changes.adoc
+++ b/sources/sections/11-changes.adoc
@@ -8,7 +8,7 @@ applied incrementally towards a _BasicDocument_ in a defined manner.
 
 
 .Basic Document model: Changes
-image::basicdoc-models/images/Change.png[]
+image::basicdoc-models/images/Changes.png[]
 
 
 === Change

--- a/sources/sections/11-changes.adoc
+++ b/sources/sections/11-changes.adoc
@@ -19,7 +19,7 @@ It contains the following attributes:
 
 `target`::  The element that this action should be applied to.
 `identifier`::  A unique identifier of this change.
-`parentIdentifier`::  One or more unique identifiers of _Change_ objects, that this change is supposed to follow after.
+`parentIdentifier`::  zero or more unique identifiers of _Change_ objects, that this change is supposed to follow after; a change with no parent is a root of a change sequence.
 `contribMetadata`::  Metadata of the contributor, see <<contributionelementmetadata>>.
 
 
@@ -106,7 +106,6 @@ It has the following attribute:
 
 `actions`:: One or more `AttributeChangeAction` data
 
-// TODO: This seems to only handle a string, not changing attribute name or attribute value?!
 
 
 === Node change

--- a/sources/sections/99-bibliography.adoc
+++ b/sources/sections/99-bibliography.adoc
@@ -9,6 +9,6 @@
 
 * [[[iso5127,ISO 5127:2017]]], _Information and documentation — Foundation and vocabulary_
 
-* [[[IEV,IEV]]], _IEV_
+* [[[IEV,IEC 60050]]], _International Electrotechnical Vocabulary (IEV Electropedia)_
 
 * [[[MIME,RFC 2045]]], _Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies_


### PR DESCRIPTION
## Summary

Three commits: (1) advance the `basicdoc-models` submodule and align diagram references; (2) codify the construct doctrine and fix the spec/model drift found in the 2026-08 audit; (3) wire in ISO 24229.

**Doctrine (normative, clause 4):** constructs specialized as types; open attribute register (`id`, `class`, `lang`, `script`, `unnumbered`, `subsequence`, `format` as well-known keys); relaxed container content models (list items, admonition/quote bodies, dl definitions, table cells, examples hold blocks); composition — a document is a block attachable as child content; variable references resolving against the register; raw content = `FormattedString` / format-qualified strings.

**New Conformance clause:** LML modules are the definitive expression; RNC grammars are implementation grammars; diagrams informative. Round-trip coverage formula for the superset claim (construct / type-specialization / register + relaxed-or-raw), with preprocessing concerns (conditionals, includes, ToC, smart punctuation, citation modes) explicitly out of scope.

**ISO 24229 (written-language conversion systems):** added to normative references; localized strings specify optional language (ISO 639), script (ISO 15924), and country (ISO 3166), whose combination identifies a **spelling system** registered under ISO 24229; the register's **system codes** identify romanization/transliteration schemes applied to content; section language/script tags reference the same correspondence. Model side: `LocalizedString` gained the country dimension (basicdoc@0bc0c90).

**Drift fixes:** `identifier` optional; section `notes` attribute dropped (a note is a block); admonition types without Statement, extensible by specialization; `Review.appliesFrom` optional + `type` attribute; `romanUpper`/`alphabetUpper` enum names; table cells and list items relaxed to block content; example content relaxed; PureTextElement distinction; STEM admits LaTeX (`stemType`/`stemValue`); image sizes as real-number/percent/auto; ruby class names; "Video is for audio files" typo; Reference-to-Variable element; `parentIdentifier` zero-or-more; `inegrityValue` typo + IntegrityValue/Hash/Signature descriptions; ISO 8601-1/-2 titles; ISO 3166 added; BasicDoc/SecureDoc aliases; **amend / NewContentBlock specified for the first time**.

## Test plan

- [x] All 16 embedded diagram references resolve at the new pin (incl. regenerated `DataTypes.png`)
- [x] Both cc-36010 and iso-36010 wire the conformance clause
- [x] Prior push's `site / build` passed (3m27s); latest push re-verifying
