### PR TITLE
Add markup-mapping and specialization/extension annexes (standardization proposal)

### DIFF
--- a/sources/cc-36010.adoc
+++ b/sources/cc-36010.adoc
@@ -56,5 +56,11 @@ include::sections/10-data-types.adoc[]
 
 include::sections/11-changes.adoc[]
 
+include::sections/aa-markup-mapping.adoc[]
+
+include::sections/ab-specialization.adoc[]
+
+include::sections/ac-extensions.adoc[]
+
 include::sections/99-bibliography.adoc[]
 

--- a/sources/iso-36010.adoc
+++ b/sources/iso-36010.adoc
@@ -57,5 +57,11 @@ include::sections/10-data-types.adoc[]
 
 include::sections/11-changes.adoc[]
 
+include::sections/aa-markup-mapping.adoc[]
+
+include::sections/ab-specialization.adoc[]
+
+include::sections/ac-extensions.adoc[]
+
 include::sections/99-bibliography.adoc[]
 

--- a/sources/sections/01a-conformance.adoc
+++ b/sources/sections/01a-conformance.adoc
@@ -17,6 +17,11 @@ document formats: a construct of such a format is covered if it maps to:
 . entries in the attribute register, together with relaxed or opaque
   (raw) content.
 
+The coverage of the principal lightweight text markup languages is
+demonstrated construct by construct in <<annex-a>>. Specialization of
+constructs is described in <<annex-b>>; extension without model change
+(register entries, opaque content, variables) in <<annex-c>>.
+
 The following are preprocessing or rendering concerns, and are out of
 scope: attribute conditionals, content inclusion, table-of-content
 generation, smart punctuation, and citation rendering modes.

--- a/sources/sections/aa-markup-mapping.adoc
+++ b/sources/sections/aa-markup-mapping.adoc
@@ -1,0 +1,92 @@
+[[annex-a]]
+[appendix,obligation=normative]
+== Mapping of lightweight text markup constructs
+
+=== General
+
+This annex demonstrates that the constructs of the principal lightweight
+text markup languages map onto the harmonized model of this document:
+one model, many markups. Each row names the markup construct and its
+model home. A construct not listed is covered by the conformance
+formula of <<conformance>>: an existing construct, a
+type-specialization of one, or register entries with relaxed or
+opaque content.
+
+Preprocessing and rendering concerns are out of scope: content
+inclusion, attribute conditionals, table-of-contents generation, smart
+punctuation, and citation rendering modes.
+
+=== AsciiDoc
+
+[cols="30%,25%,45%",options="header"]
+|===
+| AsciiDoc construct | Model home | Notes
+
+| Document header (title, author, revision) | `BasicDocument` `bibdata` + register | Document attributes become register entries
+| `=`–`======` section titles | `BasicSection` hierarchy | `[[id]]`, roles via register keys
+| Paragraph | `ParagraphBlock` | `align` option maps to `alignment`
+| `[quote]` | `QuoteBlock` | attribution/source
+| `NOTE:`, `TIP:`, `IMPORTANT:`, `WARNING:`, `CAUTION:` | `AdmonitionBlock` + `AdmonitionType` | further kinds (e.g. sidebar labels) as type-specializations
+| `====` example | `ExampleBlock` | relaxed block content
+| `-` / `*` / `.` lists | `UnorderedList`, `OrderedList` | continuations map to relaxed `ListItem` content
+| definition list | `DefinitionList` |
+| `|` table | `TableBlock` | `a|` cells map to relaxed cell content
+| `image::`/`image:` | `FigureBlock` / inline `Image` | `link`/roles via register
+| `source` block | `SourcecodeBlock` | callouts and annotations map directly
+| `stem:` | `StemElement` (`AsciiML` or `MathML`) |
+| `literal` / `[verse]` | `LiteralBlock` | verse: `format` register key over preformatted text
+| `pass:[]`, `+++` | `FormattedString` / `LiteralBlock` + `format` | raw content is non-markup
+| `{attr}` reference | `ReferenceToVariable` | resolves against the register
+| `xref:`, `<<>>`, anchors | `ReferenceToIdElement`, `Bookmark` |
+| `footnote:[]` | `Footnote` |
+| bibliography section | `ReferencesSection` + `BibliographicItem` |
+| `include::`, `toc:[]`, `ifdef{}` | — | preprocessing, out of scope
+|===
+
+=== Markdown (CommonMark, GFM, Pandoc)
+
+[cols="30%,25%,45%",options="header"]
+|===
+| Markdown construct | Model home | Notes
+
+| ATX/setext headings | `BasicSection` | `{#id .class}` via register
+| emphasis/strong/strikethrough | `EmphasisElement`, `StrongElement`, `StrikeElement` |
+| code span / fenced code | `MonospaceElement` / `SourcecodeBlock` | `:number-lines:` via register
+| bullet/ordered lists | `UnorderedList`, `OrderedList` | loose items map to relaxed `ListItem` content
+| task list `- [x]` | `ListItem` + register | `checkbox`/`completed` as register keys
+| GFM table | `TableBlock` | column alignment denormalized to cell `align`
+| links / autolinks | `ReferenceToLinkElement` |
+| images (inline) | `Image` |
+| footnotes (Pandoc/GFM) | `Footnote` |
+| `==mark==` | text element specialization | emphasis-family kind
+| `~sub~` `^sup^` | `SubscriptElement`, `SuperscriptElement` |
+| `$…$` math | `StemElement` (`LaTeX`) |
+| `[@cite]` | `Citation` + `BibliographicItem` |
+| `::: {.class}` fenced div | any relaxed container + register `class` |
+| raw HTML/TeX | `FormattedString` / `LiteralBlock` + `format` |
+| YAML front matter | document register | `BibDataExtensionType` for bibliographic keys
+|===
+
+=== reStructuredText
+
+[cols="30%,25%,45%",options="header"]
+|===
+| RST construct | Model home | Notes
+
+| section titles / transitions | `BasicSection` / `HorizontalRuleElement` |
+| bullet/enumerated lists | `UnorderedList`, `OrderedList` | `#.` auto-numbering via `start`
+| definition list | `DefinitionList` |
+| field list | document/block register | bibliographic keys to `BibDataExtensionType`
+| option list | `DefinitionList` + register `option` |
+| literal block / line block | `LiteralBlock` | line block: line breaks significant
+| block quote | `QuoteBlock` |
+| doctest block | `SourcecodeBlock` (`lang` = doctest) |
+| admonitions (note, warning, …) | `AdmonitionBlock` + `AdmonitionType` | `danger`, `error`, `hint` as type-specializations
+| `.. code::` | `SourcecodeBlock` | `:number-lines:` via register
+| `.. math::` | `StemElement` |
+| `::image:` / `::figure:` | `Image` / `FigureBlock` | `:target:` via register
+| `|substitution|` | `ReferenceToVariable` |
+| interpreted text roles | text element specializations | `:title-reference:` etc. as kinds
+| directives (incl. Sphinx) | register + relaxed content | directive name and options as register entries over any container
+| comments | — | dropped; noted as non-content
+|===

--- a/sources/sections/ab-specialization.adoc
+++ b/sources/sections/ab-specialization.adoc
@@ -1,0 +1,32 @@
+[[annex-b]]
+[appendix,obligation=informative]
+== Accommodating specializations
+
+=== Type specialization
+
+Markup-specific kinds arrive as _type values_ of a single construct,
+never as parallel classes. `AdmonitionType` defines the five generic
+kinds (_warning_, _note_, _tip_, _important_, _caution_); reStructuredText's
+_danger_, _error_, and _hint_, and domain-specific labels, are added by
+specializations of this model extending the enumeration. The same
+pattern governs `OrderedListType`, `StemType`, and `DocumentType`
+(whose generic instance carries the single value _document_).
+
+=== Attribute specialization
+
+The specialization rules of <<conformance>> permit subclasses to add,
+remove, retighten, or retype inherited attributes. A Standards-document
+specialization proscribes "hanging paragraphs" by constraining the
+co-occurrence of text blocks and subsections; a typography-conscious
+specialization may narrow `LocalizedString` usage to spelling systems
+registered under <<iso24229>>.
+
+=== Class specialization
+
+New classes subclass existing roots: block families under
+`BasicBlock`, inline elements under `BasicElement`, reference kinds
+under `ReferenceElement`. The distinction between `TextElement` and
+`PureTextElement` illustrates specialization by constraint: pure text
+elements recurse only to pure text elements, so consumers processing
+plain runs of text can rely on the distinction without inspecting the
+full hierarchy.

--- a/sources/sections/ac-extensions.adoc
+++ b/sources/sections/ac-extensions.adoc
@@ -1,0 +1,37 @@
+[[annex-c]]
+[appendix,obligation=informative]
+== Accommodating extensions
+
+=== The attribute register
+
+Extensions that would otherwise require model changes are carried as
+entries in the open attribute register (see <<conformance>>): any
+construct accepts `Attribute` entries (key, value(s), optional
+scheme). Well-known keys used across the ecosystem are `id`, `class`,
+`lang`, `script`, `unnumbered`, `subsequence`, and `format`; a markup
+dialect binds its own keys (for example, `checkbox` for task-list
+items, `option` for option-list entries) without any change to this
+model. A scheme qualifies interpretation — including ISO 24229 system
+codes identifying the romanization or transliteration scheme applied
+to content.
+
+=== Opaque and raw content
+
+Raw or passthrough content is non-markup: inline raw content is a
+`FormattedString` whose `format` attribute exists precisely to admit
+markup into strings; block-level raw content is a string-carrying
+construct (`LiteralBlock`, `SourcecodeBlock`) qualified by a `format`
+register entry. Unknown directives — including the entire Sphinx
+directive ecosystem — decompose into register entries (the directive
+name and its options) over any relaxed container, preserving both the
+content and the extension identity losslessly.
+
+=== Variables and composition
+
+Variable references (`ReferenceToVariable`) resolve against the
+register at processing time, covering AsciiDoc attribute references,
+reStructuredText substitutions, and template variables. Because a
+document is itself a block (see <<conformance>>), entire documents
+compose as child content of any relaxed container, supporting
+document-level inclusion as a structural relation rather than a
+preprocessing step.


### PR DESCRIPTION
## Summary

Prepares the document for standardization proposal, demonstrating the three accommodation claims as annexes:

- **Annex A (normative): Mapping of lightweight text markup constructs** — construct-by-construct tables for AsciiDoc, Markdown (CommonMark/GFM/Pandoc), and reStructuredText onto the harmonized model; preprocessing concerns stated out of scope; unlisted constructs covered by the conformance formula
- **Annex B (informative): Accommodating specializations** — markup-specific kinds as type values (admonition/list/stem/document types), attribute specialization (hanging-paragraph proscription example), class specialization (TextElement/PureTextElement)
- **Annex C (informative): Accommodating extensions** — the attribute register (well-known keys + markup-bound keys + ISO 24229 system codes as schemes), opaque/raw content via `FormattedString`/`format`, unknown-directive decomposition, variable references, document composition

Conformance clause now cross-references the annexes. Wired into both the CC and ISO variants.

## Test plan

- [ ] CI (metanorma-generate) green — both documents build with the annexes
