### PR TITLE
Defined terms; Annex D abstract test suite; required build on main

### DIFF
--- a/sources/cc-36010.adoc
+++ b/sources/cc-36010.adoc
@@ -62,5 +62,7 @@ include::sections/ab-specialization.adoc[]
 
 include::sections/ac-extensions.adoc[]
 
+include::sections/ad-abstract-test-suite.adoc[]
+
 include::sections/99-bibliography.adoc[]
 

--- a/sources/iso-36010.adoc
+++ b/sources/iso-36010.adoc
@@ -63,5 +63,7 @@ include::sections/ab-specialization.adoc[]
 
 include::sections/ac-extensions.adoc[]
 
+include::sections/ad-abstract-test-suite.adoc[]
+
 include::sections/99-bibliography.adoc[]
 

--- a/sources/sections/03-terms.adoc
+++ b/sources/sections/03-terms.adoc
@@ -40,6 +40,22 @@ grouping of text that can be contained within a _paragraph_ (<<term_paragraph>>)
 
 hierarchical subdivision of a document, consisting of one or more _blocks_ (<<term_block>>), and/or one or more sections
 
+=== construct
+
+generic model element provided by this document (a class, an enumeration, or a data type) which markup languages and document models specialize as types or subclasses
+
+=== attribute register
+
+open set of key-value entries, optionally qualified by a scheme, attachable to any construct, into which markup languages bind their own attribute types
+
+=== spelling system
+
+combination of language (ISO 639), script (ISO 15924), and optionally country (ISO 3166) identifying a written-language variant, as registered under <<iso24229>>
+
+=== composition
+
+attachment of an entire document, as a block, as child content of any container whose content model accepts blocks
+
 === identifier
 
 character, or group of characters, used to identify or name an item of data and possibly to indicate certain properties of that item

--- a/sources/sections/ad-abstract-test-suite.adoc
+++ b/sources/sections/ad-abstract-test-suite.adoc
@@ -1,0 +1,42 @@
+[[annex-d]]
+[appendix,obligation=normative]
+== Abstract test suite
+
+=== General
+
+This annex defines the abstract test suite for the conformance classes
+of this document. The test suite is executable: it runs as part of the
+continuous integration of the model repository, and the reference
+instance documents it consumes are maintained alongside the model.
+
+=== Conformance classes
+
+[cols="25%,45%,30%",options="header"]
+|===
+| Class | Requirement | Test
+
+| Model integrity | The LML definition modules parse, names resolve, every attribute carries an explicit visibility marker and a definition | Model lint gate
+| Diagram parity | Every diagram view includes its models and declares associations within its include closure; no class bodies under views | Parity gate
+| XML serialization | Every construct has a serializable XML form accepted by the accompanying grammar | XML instance suite against the compiled grammar
+| YAML serialization | Every construct has a serializable YAML form conforming to the model, inheritance included | YAML instance suite against the parsed model
+|===
+
+=== Test material
+
+The reference instances are twin documents — one XML, one YAML —
+exercising the attribute register (document, section, block, and inline
+levels; single and repeated values), relaxed content models (blocks
+within list items, admonition, quotation, definition-list definitions,
+table cells, examples), multi-row table headers, variable references,
+citations with a references section and bibliographic item, ruby
+annotations, source code callouts and annotations, reviewer comments,
+anchors and cross-references, and amend composition of blocks,
+sections, and entire documents. A construct without a serializable
+instance in the suite is treated as unfinished.
+
+=== Verdicts
+
+A processor or serialization passes a test if the instance validates
+against the grammar (XML) or the parsed model (YAML) without error.
+The gates abort on first failure; the test suite is regenerated from
+the model sources on every change.


### PR DESCRIPTION
## Summary

- **Defined terms**: *construct*, *attribute register*, *spelling system*, *composition* added to clause 3 — the doctrine vocabulary the normative text now relies on
- **Annex D (normative): Abstract test suite** — four conformance classes (model integrity, diagram parity, XML serialization, YAML serialization), each mapped to its executable CI gate in the model repository, with the twin reference instances as test material and the "a construct without a serializable instance is unfinished" rule stated as the verdict criterion
- basicdoc pin advanced to `5a8c132` (fixture coverage completion, lutaml-lml-based validation, atlas deep links)
- Repo hardening: `site / build` is now a **required status check** on `main` (branch protection) — the red-merge path that slipped the annex PR through is closed

## Test plan

- [ ] CI green before merge (now enforced)
