### PR TITLE
Tailoring and extension clause; profile conformance class

### DIFF
--- a/sources/sections/04-modelling.adoc
+++ b/sources/sections/04-modelling.adoc
@@ -28,6 +28,32 @@ construct is covered by this model if it maps to an existing construct, a
 type-specialization of one, or register entries with relaxed or opaque
 content (see <<conformance>>).
 
+=== Tailoring and extension
+
+Users adapt this model through three layers, none of which modifies
+the basis (open-closed):
+
+* *Extension of instances* — the attribute register, format-qualified
+  raw content, and variable references carry dialect-specific
+  information losslessly, with no tooling beyond the base model.
+* *Extension of the model* — a specialization module defines new
+  classes under the construct roots, extends enumerations, and narrows
+  inherited attributes, as described above; it is a layer above this
+  model, never a change to it.
+* *Tailoring* — a _profile_ declares a subset of this model: the
+  constructs it excludes, the cardinalities it narrows, the
+  enumeration values it admits, and the closed vocabulary of register
+  keys it permits.
+
+A profile shall only narrow the base: it shall not widen any
+cardinality, admit enumeration values outside the base, add
+constructs, or rename them. Extensions live above a profile, as
+specialization modules. Profiles are expressed as declarative
+artifacts alongside the model, and are validated mechanically with
+the model repository's test suite (see <<annex-d>>); an instance that
+conforms to a profile is always a conforming instance of the base
+model.
+
 === Attribute register
 
 Attributes form an open _register_: any construct (document, section, block,

--- a/sources/sections/ad-abstract-test-suite.adoc
+++ b/sources/sections/ad-abstract-test-suite.adoc
@@ -19,6 +19,7 @@ instance documents it consumes are maintained alongside the model.
 | Diagram parity | Every diagram view includes its models and declares associations within its include closure; no class bodies under views | Parity gate
 | XML serialization | Every construct has a serializable XML form accepted by the accompanying grammar | XML instance suite against the compiled grammar
 | YAML serialization | Every construct has a serializable YAML form conforming to the model, inheritance included | YAML instance suite against the parsed model
+| Profile conformance | A profile narrows only: names exist, cardinalities never widen, enumerations are subsets; profile instances contain no excluded construct and use permitted register keys only | Profile suite against the model and worked instances
 |===
 
 === Test material


### PR DESCRIPTION
## Summary

Answers "how do users tailor (choose less) and extend" as normative text:

- **Clause 4, "Tailoring and extension"**: the three-layer mechanism — *extension of instances* (register/raw/variables, no tooling), *extension of the model* (specialization modules above the base), *tailoring* (**profiles**: declarative subsets — excluded constructs, narrowed cardinalities, enum subsets, closed register-key vocabulary)
- **Profiling rule made normative**: a profile shall only narrow — no widened cardinality, no enum values outside the base, no added or renamed constructs; extensions live above a profile; a profile-conforming instance is always base-conforming
- **Annex D**: new *profile conformance* class mapped to the mechanically validated profile suite (narrowing-only enforcement + worked instances, running in the model repository's CI)
- basicdoc pin advanced to `395e863` (profiles tree, with `legalexchange/1.0` as the worked example)

## Test plan

- [x] All 16 embedded diagram references resolve at the new pin
- [ ] CI green before merge (required)
